### PR TITLE
fix: resolve type error in history management functions

### DIFF
--- a/src/hooks/graph/useSync.ts
+++ b/src/hooks/graph/useSync.ts
@@ -30,6 +30,10 @@ const useSync = () => {
     return typeof playlist === 'object' && playlist !== null && 'title' in playlist && 'fileList' in playlist
   }
 
+  function isTrack(item: unknown): item is Track {
+    return typeof item === 'object' && item !== null && 'id' in item && typeof item.id === 'string' && 'name' in item && typeof item.name === 'string'
+  }
+
   // 自动从 OneDrive 获取应用数据
   const appDatafetcher = async () => {
     if (!account) return {
@@ -61,7 +65,7 @@ const useSync = () => {
           size: item.fileSize,
         })
         : item
-    )
+    ).filter(isTrack)
 
     const playlists: Playlist[] = remotePlaylists.map((playlist) =>
       isOldPlaylist(playlist)
@@ -75,7 +79,10 @@ const useSync = () => {
             size: item.fileSize,
           })),
         })
-        : playlist
+        : {
+          ...playlist,
+          files: playlist.files.filter(isTrack),
+        }
     )
 
     return {

--- a/src/store/useHistoryStore.ts
+++ b/src/store/useHistoryStore.ts
@@ -1,6 +1,15 @@
 import { HistoryActions, HistoryState } from '../types/history'
+import { Track } from '../types/file'
 import { create } from 'zustand'
 import createSelectors from './createSelectors'
+
+const hasSameNonEmptyPath = (a: Track, b: Track) => (
+  Array.isArray(a.path)
+  && a.path.length > 0
+  && Array.isArray(b.path)
+  && b.path.length > 0
+  && a.path.join('/') === b.path.join('/')
+)
 
 const useHistoryStoreBase = create<HistoryState & HistoryActions>(
   (set) => ({
@@ -13,7 +22,7 @@ const useHistoryStoreBase = create<HistoryState & HistoryActions>(
             historys:
               [
                 file,
-                ...state.historys.filter((item) => item.path.join('/') !== file.path.join('/'))
+                ...state.historys.filter((item) => !hasSameNonEmptyPath(item, file)),
               ].slice(0, 200)
           }
           : { historys: [file] }


### PR DESCRIPTION
1. 读取`history.json`和`playlists.json`时进行类型守卫过滤。
2. 在去重时，仅当`path`字段有效才进行比较。

fix #138 